### PR TITLE
chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,18 +21,10 @@ permissions:
 
 jobs:
   check-dist:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
 
-    permissions:
-      id-token: write
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Set Node.js 20.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,9 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    runs-on: github-hosted-small
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -37,17 +29,9 @@ jobs:
         run: |
           npm test
   lint:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    runs-on: github-hosted-small
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: 'ubuntu-latest'
+    runs-on: 'github-hosted-small'
     timeout-minutes: 360
     permissions:
       # required for all workflows
@@ -26,12 +26,6 @@ jobs:
         language: [ 'javascript-typescript' ]
 
     steps:
-    - name: Harden the runner
-      uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-      with:
-        egress-policy: block
-        policy: global-allowed-endpoints-policy
-
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,17 +6,9 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    runs-on: github-hosted-small
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: 'Checkout Repository'
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Dependency Review

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,17 +10,9 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    runs-on: github-hosted-small
 
     steps:
-    - name: Harden the runner
-      uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-      with:
-        egress-policy: block
-        policy: global-allowed-endpoints-policy
-
     - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
       name: Clean up stale PRs and Issues
       with:


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use custom hosted runners that have StepSecurity built-in, removing the need for the explicit StepSecurity harden-runner action.

## What Changed
- Removed step-security/harden-runner action steps (no longer needed as StepSecurity is built into custom runners)
- Removed id-token: write permissions (no longer needed without the StepSecurity action)
- Updated runs-on from ubuntu-latest to github-hosted-small (custom runners with built-in StepSecurity)
- Converted non-circlefin action versions to commit SHAs with version comments for security pinning (e.g., actions/checkout@abc123 # v3.6.0)
- circlefin GitHub actions remain unchanged

## Purpose
Our custom hosted runners (github-hosted-small) now have StepSecurity built-in at the runner level, so we no longer need to add it as an explicit step in each workflow. This simplifies our workflows while maintaining the same security posture.

## Testing
- All workflow syntax changes have been validated
- No functional changes to workflow behavior
- StepSecurity protection is maintained via the custom runners
- Review the diff to ensure only intended changes occurred